### PR TITLE
Data base names should follow the rules of SQL, so I changed the name…

### DIFF
--- a/server/config/config.json
+++ b/server/config/config.json
@@ -2,21 +2,21 @@
   "development": {
     "username": "postgres",
     "password": "root", 
-    "database": "CC-Development",
+    "database": "ccdevelopment",
     "host": "127.0.0.1",
     "dialect": "postgres"
   },
   "test": {
     "username": "postgres",
     "password": "root",
-    "database": "CC-Test",
+    "database": "cctest",
     "host": "127.0.0.1",
     "dialect": "postgres"
   },
   "production": {
     "username": "root",
     "password": null,
-    "database": "CC-Production",
+    "database": "ccproduction",
     "host": "127.0.0.1",
     "dialect": "postgres"
   }


### PR DESCRIPTION
…s in config.json to be lowercase with no hyphens.